### PR TITLE
Fixes count variable in drg.tf

### DIFF
--- a/drg.tf
+++ b/drg.tf
@@ -8,7 +8,7 @@
 
 
 resource "oci_core_drg" "DynamicRoutingGateway" {
-  count          = var.drg_display_name != "" && length(local.hub_drg) == 0 ? 1 : 0
+  count          = var.drg_display_name != "" && !var.is_spoke ? 1 : 0
   compartment_id = local.nw_compartment_ocid
 
   display_name = var.drg_display_name


### PR DESCRIPTION
When working on the example deployments of this I found an issue as the SPOKES relied on checking if the DRG was already provisioned. This wasn't possible as the resource won't be created yet, throwing an error. Instead a simpler check of whether it is a spoke or not makes much more sense.